### PR TITLE
Fix/modal close preserve state

### DIFF
--- a/src/core/store/modal-window-store.ts
+++ b/src/core/store/modal-window-store.ts
@@ -14,8 +14,13 @@ type ModalWindowType = {
     size: ModalSize;
 };
 
+type OpenModalPayload = {
+    title: string;
+    content: React.ReactNode | React.ComponentType;
+};
+
 type ModalWindowStoreActions = {
-    openModal({ title, content }: { title: string, content: React.ReactNode | React.ComponentType }): void;
+    openModal(payload: OpenModalPayload): void;
     closeModal(): void;
 };
 

--- a/src/core/store/modal-window-store.ts
+++ b/src/core/store/modal-window-store.ts
@@ -51,8 +51,8 @@ export const createModalWindowStore: StoreStateType<ModalWindowStoreType> = (set
         set((state) => ({
             modalWindow: {
                 ...state.modalWindow,
-                ...initialState,
-            }
+                isModalOpen: false,
+            },
         }));
-    }
+    },
 });

--- a/src/core/store/modal-window-store.ts
+++ b/src/core/store/modal-window-store.ts
@@ -51,7 +51,7 @@ export const createModalWindowStore: StoreStateType<ModalWindowStoreType> = (set
         set((state) => ({
             modalWindow: {
                 ...state.modalWindow,
-                isModalOpen: false,
+                ...initialState,
             },
         }));
     },


### PR DESCRIPTION
- Updated openModal to take a single payload object for cleaner code.

- Changed closeModal to just set isModalOpen to false so the modal content doesn’t get cleared when closing.